### PR TITLE
Improve command whitelist

### DIFF
--- a/src/main/java/pl/plajer/murdermystery/events/Events.java
+++ b/src/main/java/pl/plajer/murdermystery/events/Events.java
@@ -190,8 +190,10 @@ public class Events implements Listener {
     if (!plugin.getConfig().getBoolean("Block-Commands-In-Game", true)) {
       return;
     }
+    String command = event.getMessage().substring(1);
+    command = (command.indexOf(' ') >= 0 ? command.substring(0, command.indexOf(' ')) : command);
     for (String msg : plugin.getConfig().getStringList("Whitelisted-Commands")) {
-      if (event.getMessage().contains(msg)) {
+      if (command.equalsIgnoreCase(msg)) {
         return;
       }
     }


### PR DESCRIPTION
Without this change, if "msg" was whitelisted, it was possible to write something like "/anycommand msg" and it would be accepted.  This patch changes the handling to check the part of the command before the first space if the command contains any spaces or the whole command otherwise. So whitelisting "msg" will allow "/msg" and "/msg anyone", but not "/anycommand msg"