### PR TITLE
Add a toggle for showing where an arena's gold spawns

### DIFF
--- a/src/main/java/plugily/projects/murdermystery/arena/Arena.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/Arena.java
@@ -32,6 +32,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitScheduler;
 import org.golde.bukkit.corpsereborn.CorpseAPI.CorpseAPI;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -87,6 +88,7 @@ public class Arena extends BukkitRunnable {
   private final ScoreboardManager scoreboardManager;
   private List<Location> goldSpawnPoints = new ArrayList<>();
   private List<Location> playerSpawnPoints = new ArrayList<>();
+  private int goldVisualsRunnableId = -1;
 
   private int murderers = 0;
   private int detectives = 0;
@@ -567,6 +569,27 @@ public class Arena extends BukkitRunnable {
 
   public void setGoldSpawnPoints(@NotNull List<Location> goldSpawnPoints) {
     this.goldSpawnPoints = goldSpawnPoints;
+  }
+
+  public void toggleGoldVisuals() {
+    BukkitScheduler scheduler = plugin.getServer().getScheduler();
+    int id = this.goldVisualsRunnableId;
+    if (id != -1) {
+      scheduler.cancelTask(id);
+      this.goldVisualsRunnableId = -1;
+    } else {
+      this.goldVisualsRunnableId = scheduler.scheduleSyncRepeatingTask(plugin, () -> {
+        for (Location goldLocation : goldSpawnPoints) {
+          Location particleLocation = goldLocation.clone();
+          particleLocation.add(0, 0.4, 0);
+          goldLocation.getWorld().spawnParticle(Particle.REDSTONE, particleLocation, 10, 0.1, 0.2, 0.1, new Particle.DustOptions(Color.YELLOW, 1));
+        }
+      }, 1, 1);
+    }
+  }
+
+  public boolean isGoldVisualsEnabled() {
+    return this.goldVisualsRunnableId != -1;
   }
 
   /**

--- a/src/main/java/plugily/projects/murdermystery/handlers/setup/components/MiscComponents.java
+++ b/src/main/java/plugily/projects/murdermystery/handlers/setup/components/MiscComponents.java
@@ -193,6 +193,14 @@ public class MiscComponents implements SetupComponent {
       new SetupInventory(arena, setupInventory.getPlayer()).openInventory();
     }), 7, 1);
 
+    pane.addItem(new GuiItem(new ItemBuilder(XMaterial.GOLD_ORE.parseItem())
+      .name(chatManager.colorRawMessage(arena.isGoldVisualsEnabled() ? "&e&lDisable Gold Visuals" : "&e&lEnable Gold Visuals"))
+      .lore(ChatColor.GRAY + "Disabled on server restart")
+      .build(), e -> {
+      e.getWhoClicked().closeInventory();
+      arena.toggleGoldVisuals();
+    }), 7, 2);
+
     pane.addItem(new GuiItem(new ItemBuilder(XMaterial.FILLED_MAP.parseItem())
       .name(chatManager.colorRawMessage("&e&lView Setup Video"))
       .lore(ChatColor.GRAY + "Having problems with setup or wanna")


### PR DESCRIPTION
When deciding where to place gold, it's quite difficult to keep track of the density of gold in an area, and whether or not you've been through there before. This is made even harder when working with another person and trying to re-balance after the first setup.
These problems require that the solution be very easily noticed when enabled, so I added a toggle for spawning a mass of particles at each gold spawn location.
I did not attempt to make it look pretty because it's not intended for actual play. This is the reason that it does not get saved in the config.