### PR TITLE
fixing bungeecord shutdown issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .*
 /minecraft/
 /target/
+murdermystery.iml

--- a/src/main/java/plugily/projects/murdermystery/arena/Arena.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/Arena.java
@@ -481,10 +481,16 @@ public class Arena extends BukkitRunnable {
                 Bukkit.shutdown ();
               }
             }, 5, 5);
+            
+            setArenaState (ArenaState.SHUTTING_DOWN);
+          } else {
+            setArenaState (ArenaState.RESTARTING);
           }
-          setArenaState(ArenaState.RESTARTING);
         }
         setTimer(getTimer() - 1);
+        break;
+      case SHUTTING_DOWN:
+        // nothing to do here but i'll put it in the switch just in case
         break;
       case RESTARTING:
         players.clear();

--- a/src/main/java/plugily/projects/murdermystery/arena/Arena.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/Arena.java
@@ -31,6 +31,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.golde.bukkit.corpsereborn.CorpseAPI.CorpseAPI;
 import org.jetbrains.annotations.NotNull;
@@ -475,7 +476,11 @@ public class Arena extends BukkitRunnable {
           cleanUpArena();
           if(plugin.getConfigPreferences().getOption(ConfigPreferences.Option.BUNGEE_ENABLED)
               && ConfigUtils.getConfig(plugin, "bungee").getBoolean("Shutdown-When-Game-Ends")) {
-            plugin.getServer().shutdown();
+            Bukkit.getScheduler ().scheduleSyncRepeatingTask (plugin, (Runnable)() -> {
+              if (Bukkit.getOnlinePlayers ().isEmpty ()) {
+                Bukkit.shutdown ();
+              }
+            }, 5, 5);
           }
           setArenaState(ArenaState.RESTARTING);
         }

--- a/src/main/java/plugily/projects/murdermystery/arena/ArenaEvents.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/ArenaEvents.java
@@ -392,7 +392,7 @@ public class ArenaEvents implements Listener {
     player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 3 * 20, 0));
     if(arena.getArenaState() == ArenaState.STARTING) {
       return;
-    } else if(arena.getArenaState() == ArenaState.ENDING || arena.getArenaState() == ArenaState.RESTARTING) {
+    } else if(arena.getArenaState() == ArenaState.ENDING || arena.getArenaState() == ArenaState.RESTARTING || arena.getArenaState() == ArenaState.SHUTTING_DOWN) {
       player.getInventory().clear();
       player.setFlying(false);
       player.setAllowFlight(false);
@@ -420,7 +420,7 @@ public class ArenaEvents implements Listener {
     player.setFlying(true);
     player.getInventory().clear();
     chatManager.broadcastAction(arena, player, ChatManager.ActionType.DEATH);
-    if(arena.getArenaState() != ArenaState.ENDING && arena.getArenaState() != ArenaState.RESTARTING) {
+    if(arena.getArenaState() != ArenaState.ENDING && arena.getArenaState() != ArenaState.RESTARTING && arena.getArenaState() != ArenaState.SHUTTING_DOWN) {
       arena.addDeathPlayer(player);
     }
     //we must call it ticks later due to instant respawn bug
@@ -442,7 +442,7 @@ public class ArenaEvents implements Listener {
     if(arena.getArenaState() == ArenaState.STARTING || arena.getArenaState() == ArenaState.WAITING_FOR_PLAYERS) {
       e.setRespawnLocation(arena.getLobbyLocation());
       return;
-    } else if(arena.getArenaState() == ArenaState.ENDING || arena.getArenaState() == ArenaState.RESTARTING) {
+    } else if(arena.getArenaState() == ArenaState.ENDING || arena.getArenaState() == ArenaState.RESTARTING || arena.getArenaState() == ArenaState.SHUTTING_DOWN) {
       e.setRespawnLocation(arena.getEndLocation());
       return;
     }

--- a/src/main/java/plugily/projects/murdermystery/arena/ArenaManager.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/ArenaManager.java
@@ -130,7 +130,7 @@ public class ArenaManager {
           PermissionsManager.getJoinPerm().replace("<arena>", arena.getId())));
       return;
     }
-    if(arena.getArenaState() == ArenaState.RESTARTING) {
+    if(arena.getArenaState() == ArenaState.RESTARTING || arena.getArenaState() == ArenaState.SHUTTING_DOWN) {
       return;
     }
     if(arena.getPlayers().size() >= arena.getMaximumPlayers() && arena.getArenaState() == ArenaState.STARTING) {

--- a/src/main/java/plugily/projects/murdermystery/arena/ArenaState.java
+++ b/src/main/java/plugily/projects/murdermystery/arena/ArenaState.java
@@ -28,7 +28,7 @@ import plugily.projects.murdermystery.Main;
  * Contains all GameStates.
  */
 public enum ArenaState {
-  WAITING_FOR_PLAYERS("Waiting"), STARTING("Starting"), IN_GAME("In-Game"), ENDING("Ending"), RESTARTING("Restarting");
+  WAITING_FOR_PLAYERS("Waiting"), STARTING("Starting"), IN_GAME("In-Game"), ENDING("Ending"), RESTARTING("Restarting"), SHUTTING_DOWN ("Shutting Down");
 
   private final String formattedName;
   private final String placeholder;

--- a/src/main/java/plugily/projects/murdermystery/handlers/BungeeManager.java
+++ b/src/main/java/plugily/projects/murdermystery/handlers/BungeeManager.java
@@ -63,6 +63,7 @@ public class BungeeManager implements Listener {
     gameStateToString.put(ArenaState.IN_GAME, chatManager.colorRawMessage(bungee.getString("MOTD.Game-States.In-Game", "In-Game")));
     gameStateToString.put(ArenaState.ENDING, chatManager.colorRawMessage(bungee.getString("MOTD.Game-States.Ending", "Ending")));
     gameStateToString.put(ArenaState.RESTARTING, chatManager.colorRawMessage(bungee.getString("MOTD.Game-States.Restarting", "Restarting")));
+    gameStateToString.put(ArenaState.SHUTTING_DOWN, chatManager.colorRawMessage(bungee.getString("MOTD.Game-States.Shutting-Down", "Shutting-Down")));
     motd = chatManager.colorRawMessage(bungee.getString("MOTD.Message", "The actual game state of mm is %state%"));
     plugin.getServer().getMessenger().registerOutgoingPluginChannel(plugin, "BungeeCord");
     plugin.getServer().getPluginManager().registerEvents(this, plugin);

--- a/src/main/java/plugily/projects/murdermystery/handlers/language/LanguageMigrator.java
+++ b/src/main/java/plugily/projects/murdermystery/handlers/language/LanguageMigrator.java
@@ -117,7 +117,8 @@ public class LanguageMigrator {
               "    Starting: \"&e&lStarting\"\r\n" +
               "    Full-Game: \"&4&lFULL\"\r\n" +
               "    Ending: \"&lEnding\"\r\n" +
-              "    Restarting: \"&c&lRestarting\"\r\n");
+              "    Restarting: \"&c&lRestarting\"\r\n" +
+              "    Shutting-Down: \"&c&lShutting down\"\r\n");
           break;
         case 9:
           MigratorUtils.addNewLines(file, "\r\n" +
@@ -201,7 +202,8 @@ public class LanguageMigrator {
               "    Starting: YELLOW_wool\r\n" +
               "    In-Game: RED_wool\r\n" +
               "    Ending: RED_wool\r\n" +
-              "    Restarting: RED_wool\r\n");
+              "    Restarting: RED_wool\r\n" +
+              "    Shutting-Down: RED_wool\r\n");
           break;
         case 22:
           MigratorUtils.addNewLines(file, "\r\n#Add trails that you want to blacklist from all trails(particles)\r\n" +
@@ -272,7 +274,8 @@ public class LanguageMigrator {
               "    Starting: \"&e&lStarting\"\r\n" +
               "    In-Game: \"&lPlaying\"\r\n" +
               "    Ending: \"&lEnding\"\r\n" +
-              "    Restarting: \"&c&lRestarting\"\r\n");
+              "    Restarting: \"&c&lRestarting\"\r\n" +
+              "    Shutting-Down: \"&c&lShutting down\"\r\n");
           break;
         case 6:
           //No migrator as we can't handle that

--- a/src/main/java/plugily/projects/murdermystery/handlers/language/LanguageMigrator.java
+++ b/src/main/java/plugily/projects/murdermystery/handlers/language/LanguageMigrator.java
@@ -34,8 +34,8 @@ import java.io.File;
 @SuppressWarnings("deprecation")
 public class LanguageMigrator {
 
-  public static final int CONFIG_FILE_VERSION = 23;
-  public static final int LANGUAGE_FILE_VERSION = 7;
+  public static final int CONFIG_FILE_VERSION = 24;
+  public static final int LANGUAGE_FILE_VERSION = 8;
   private final Main plugin;
 
   public LanguageMigrator(Main plugin) {

--- a/src/main/java/plugily/projects/murdermystery/handlers/sign/SignManager.java
+++ b/src/main/java/plugily/projects/murdermystery/handlers/sign/SignManager.java
@@ -73,6 +73,7 @@ public class SignManager implements Listener {
     gameStateToString.put(ArenaState.IN_GAME, chatManager.colorMessage("Signs.Game-States.In-Game"));
     gameStateToString.put(ArenaState.ENDING, chatManager.colorMessage("Signs.Game-States.Ending"));
     gameStateToString.put(ArenaState.RESTARTING, chatManager.colorMessage("Signs.Game-States.Restarting"));
+    gameStateToString.put(ArenaState.SHUTTING_DOWN, chatManager.colorMessage("Signs.Game-States.Shutting-Down"));
     signLines = LanguageManager.getLanguageList("Signs.Lines");
     plugin.getServer().getPluginManager().registerEvents(this, plugin);
   }
@@ -246,6 +247,7 @@ public class SignManager implements Listener {
               }
               break;
             case RESTARTING:
+            case SHUTTING_DOWN:
               behind.setType(XMaterial.BLACK_STAINED_GLASS.parseMaterial());
               if(ServerVersion.Version.isCurrentLower(ServerVersion.Version.v1_13_R1)) {
                 Block.class.getMethod("setData", byte.class).invoke(behind, (byte) 15);

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -25,3 +25,4 @@ MOTD:
     Full-Game: "&4&lFULL"
     Ending: "&lEnding"
     Restarting: "&c&lRestarting"
+    Shutting-Down: "&c&lShutting down"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -204,6 +204,6 @@ Blacklisted-Trails:
   - "block_dust"
 
 # Don't modify.
-Version: 23
+Version: 24
 
 # No way! You've reached the end! But... where's the dragon!?

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -171,7 +171,7 @@ Nametags-Hidden: true
 # - yellow (starting) stained glass
 # - orange (in game) stained glass
 # - gray (ending) stained glass
-# - black (restarting) stained glass
+# - black (restarting/shutting down) stained glass
 Signs-Block-States-Enabled: true
 
 
@@ -183,6 +183,7 @@ Arena-Selector:
     In-Game: RED_wool
     Ending: RED_wool
     Restarting: RED_wool
+    Shutting-Down: RED_wool
 
 Update-Notifier:
   # Should we check for updates on plugin start/after admin join?

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -272,6 +272,7 @@ Signs:
     Full-Game: "&4&lFULL"
     Ending: "&lEnding"
     Restarting: "&c&lRestarting"
+    Shutting-Down: "&c&lShutting down"
   Lines:
     - "&4&lMurder Mystery"
     - "%state%"
@@ -316,6 +317,7 @@ Placeholders:
     In-Game: "&lIn-game"
     Ending: "&lEnding"
     Restarting: "&c&lRestarting"
+    Shutting-Down: "&c&lShutting down"
 
 # Don't edit it. But who's stopping you? It's your server!
 # Really, don't edit ;p

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -321,4 +321,4 @@ Placeholders:
 
 # Don't edit it. But who's stopping you? It's your server!
 # Really, don't edit ;p
-File-Version-Do-Not-Edit: 7
+File-Version-Do-Not-Edit: 8

--- a/src/main/resources/locales/language_default.yml
+++ b/src/main/resources/locales/language_default.yml
@@ -268,6 +268,7 @@ Signs:
     Full-Game: "&4&lFULL"
     Ending: "&lEnding"
     Restarting: "&c&lRestarting"
+    Shutting-Down: "&c&lShutting down"
   Lines:
     - "&4&lMurder Mystery"
     - "%state%"
@@ -312,6 +313,7 @@ Placeholders:
     In-Game: "&lIn-game"
     Ending: "&lEnding"
     Restarting: "&c&lRestarting"
+    Shutting-Down: "&c&lShutting down"
 
 # Don't edit it. But who's stopping you? It's your server!
 # Really, don't edit ;p


### PR DESCRIPTION
there is an issue where when the bungeecord shutdown on end option is enabled, if the lobby server is a paper server then most players will be kicked off of the network by the server shutdown instead of being sent to the lobby. this is caused because the shutdown starts on the exact same tick that the player sendoff is started, which means even the slightest bit of delay will kick players off. even a redirect plugin can't fix this because a connection is already being established. this is especially an issue with paper because by default it only allows 3 new player joins per tick, meaning all but 3 people will be kicked off the network. this fix makes it so that the shutdown is schedules instead, waiting until all players have been successfully disconnected. i have also added a new "shutting down" state specifically for these types of servers, which will not allow new players to join, but won't start a new game like the restarting state.